### PR TITLE
Run release-actions.sh on Heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: python manage.py migrate
+release: ./deployment/release-actions.sh
 web: gunicorn platypus.wsgi --log-file -

--- a/deployment/release-actions.sh
+++ b/deployment/release-actions.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# These actions are intended to be run during the Heroku release phase.
+# The script should not be run manually
+python manage.py migrate
+python manage.py loaddata recipes.json


### PR DESCRIPTION
Performs similar actions to `reset-database.sh` automatically on Heroku deployment.