### PR TITLE
Expand sitemap

### DIFF
--- a/recipes/sitemap.py
+++ b/recipes/sitemap.py
@@ -3,7 +3,7 @@ from django.contrib.sitemaps import Sitemap
 from recipes.models import Recipe
 
 
-class RecipeSitemap(Sitemap):
+class RecipePageSitemap(Sitemap):
     changefreq = "monthly"
     protocol = "https"
 
@@ -12,3 +12,14 @@ class RecipeSitemap(Sitemap):
 
     def lastmod(self, item):
         return item.published_date
+
+
+class SupportPageSitemap(Sitemap):
+    changefreq = "monthly"
+    protocol = "https"
+
+    def items(self):
+        return ['/', '/planner/', '/about/']
+
+    def location(self, item):
+        return item

--- a/recipes/sitemap.py
+++ b/recipes/sitemap.py
@@ -1,0 +1,14 @@
+from django.contrib.sitemaps import Sitemap
+
+from recipes.models import Recipe
+
+
+class RecipeSitemap(Sitemap):
+    changefreq = "monthly"
+    protocol = "https"
+
+    def items(self):
+        return Recipe.objects.all()
+
+    def lastmod(self, item):
+        return item.published_date

--- a/recipes/tests/test_sitemap.py
+++ b/recipes/tests/test_sitemap.py
@@ -25,8 +25,16 @@ class SitemapTest(TestCase):
         self.assertEqual(len(recipe_loc_elements), recipe_count, "All recipes have an entry")
 
     def test_sitemap_has_entry_for_index_page(self):
-        recipe_loc_elements = self._sitemap_loc_elements(r"^https://testserver/recipes/$")
-        self.assertEqual(len(recipe_loc_elements), 1, "Index page has an entry")
+        index_loc_elements = self._sitemap_loc_elements(r"^https://testserver/$")
+        self.assertEqual(len(index_loc_elements), 1, "Index page has an entry")
+
+    def test_sitemap_has_entry_for_about_page(self):
+        about_loc_elements = self._sitemap_loc_elements(r"^https://testserver/about/$")
+        self.assertEqual(len(about_loc_elements), 1, "About page has an entry")
+
+    def test_sitemap_has_entry_for_planner_page(self):
+        planner_loc_elements = self._sitemap_loc_elements(r"^https://testserver/planner/$")
+        self.assertEqual(len(planner_loc_elements), 1, "Planner page has an entry")
 
     def _sitemap_loc_elements(self, regex=None):
         response = client.get('/sitemap.xml')

--- a/recipes/tests/test_sitemap.py
+++ b/recipes/tests/test_sitemap.py
@@ -21,8 +21,12 @@ class SitemapTest(TestCase):
 
     def test_sitemap_has_entry_for_each_recipe(self):
         recipe_count = Recipe.objects.all().count()
-        recipe_log_elements = self._sitemap_loc_elements(r"^https://testserver/recipes/\d+/[a-z-]+/$")
-        self.assertEqual(len(recipe_log_elements), recipe_count, "All recipes have an entry")
+        recipe_loc_elements = self._sitemap_loc_elements(r"^https://testserver/recipes/\d+/[a-z-]+/$")
+        self.assertEqual(len(recipe_loc_elements), recipe_count, "All recipes have an entry")
+
+    def test_sitemap_has_entry_for_index_page(self):
+        recipe_loc_elements = self._sitemap_loc_elements(r"^https://testserver/recipes/$")
+        self.assertEqual(len(recipe_loc_elements), 1, "Index page has an entry")
 
     def _sitemap_loc_elements(self, regex=None):
         response = client.get('/sitemap.xml')

--- a/recipes/urls.py
+++ b/recipes/urls.py
@@ -2,11 +2,14 @@ from django.contrib.sitemaps.views import sitemap
 from django.urls import path
 
 from . import views
-from .sitemap import RecipeSitemap
+from .sitemap import RecipePageSitemap, SupportPageSitemap
 
 app_name = 'recipes'
 
-sitemaps = {'dynamic': RecipeSitemap}
+sitemaps = {
+    'recipe_pages': RecipePageSitemap,
+    'support_pages': SupportPageSitemap
+}
 
 urlpatterns = [
     path('', views.index, name='index'),
@@ -14,7 +17,5 @@ urlpatterns = [
     path('planner/', views.planner, name='planner'),
     path('<int:recipe_id>/<str:slug>/', views.detail, name='detail_with_slug'),
     path('<int:recipe_id>/', views.detail, name='detail'),
-    path('sitemap.xml', sitemap,
-         {'sitemaps': sitemaps},
-         name='django.contrib.sitemaps.views.sitemap'),
+    path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap')
 ]

--- a/recipes/urls.py
+++ b/recipes/urls.py
@@ -1,16 +1,12 @@
-from django.contrib.sitemaps import GenericSitemap
 from django.contrib.sitemaps.views import sitemap
 from django.urls import path
 
 from . import views
-from .models import Recipe
+from .sitemap import RecipeSitemap
 
 app_name = 'recipes'
 
-info_dict = {
-    'queryset': Recipe.objects.all(),
-    'date_field': 'published_date',
-}
+sitemaps = {'dynamic': RecipeSitemap}
 
 urlpatterns = [
     path('', views.index, name='index'),
@@ -19,6 +15,6 @@ urlpatterns = [
     path('<int:recipe_id>/<str:slug>/', views.detail, name='detail_with_slug'),
     path('<int:recipe_id>/', views.detail, name='detail'),
     path('sitemap.xml', sitemap,
-         {'sitemaps': {'blog': GenericSitemap(info_dict, changefreq="monthly", protocol="https")}},
+         {'sitemaps': sitemaps},
          name='django.contrib.sitemaps.views.sitemap'),
 ]


### PR DESCRIPTION
Expands sitemap to include non-recipe pages such as the index and about pages.

Replaces inline GenericSitemap with a custom `sitemap.py` module containing multiple `Sitemap` classes referenced from `urls.py`.